### PR TITLE
Rue Froidevaux non satisfaisante

### DIFF
--- a/planvelo-pratique.geojson
+++ b/planvelo-pratique.geojson
@@ -883,10 +883,11 @@
     {
       "type": "Feature",
       "properties": {
-        "stroke": "#228b22",
+        "stroke": "#ffa500",
         "stroke-width": 4,
         "stroke-opacity": 1,
-        "name": "Rue Froidevaux"
+        "name": "Rue Froidevaux",
+        "description": "Piste très difficile d'accès depuis le carrefour de l'avenue du Maine"
       },
       "geometry": {
         "type": "LineString",

--- a/planvelo-pratique.geojson
+++ b/planvelo-pratique.geojson
@@ -887,7 +887,7 @@
         "stroke-width": 4,
         "stroke-opacity": 1,
         "name": "Rue Froidevaux",
-        "description": "Piste très difficile d'accès depuis le carrefour de l'avenue du Maine"
+        "description": "Piste dans le sens Ouest-Est très difficile d'accès notamment depuis le carrefour de l'avenue du Maine"
       },
       "geometry": {
         "type": "LineString",


### PR DESCRIPTION
La piste de la rue Froidevaux est pratiquement inaccessible depuis le carrefour de l'avenue du Maine. Sa situation, où l'on roule à gauche des voitures, la rend très peu pratique et très peu utilisée par les cyclistes dans le sens Ouest-Est.